### PR TITLE
Allow empty rockets other than cargo rockets to reach their destinations, even across dimensions

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/api/prefab/entity/EntityTieredRocket.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/api/prefab/entity/EntityTieredRocket.java
@@ -368,10 +368,24 @@ public abstract class EntityTieredRocket extends EntityAutoRocket implements IRo
                     		if (this.riddenByEntity != null)
                     		{
                     			WorldUtil.transferEntityToDimension(this.riddenByEntity, this.targetDimension, (WorldServer) targetDim.worldObj, false, this);
+                                        //Now destroy the rocket entity, the rider is switching dimensions
+                                        this.setDead();
                     		}
-                    		//Now destroy the rocket entity, the rider is switching dimensions
-                    		//or if there is no rider, the rocket can be destroyed anyhow (Cargo Rockets override this)
-                    		this.setDead();
+                                else {
+                                    Entity e = WorldUtil.transferEntityToDimension(this, this.targetDimension, (WorldServer)targetDim.worldObj, false, null);
+                                    if(e instanceof EntityAutoRocket) {
+                                        e.setPosition(this.targetVec.x + 0.5F, this.targetVec.y + 800, this.targetVec.z + 0.5f);
+                                        ((EntityAutoRocket)e).landing = true;
+                                        ((EntityAutoRocket)e).setWaitForPlayer(false);
+                                        if(e != this)
+                                            this.setDead();
+                                    }
+                                    else {
+                                        GCLog.info("Error: failed to recreate the unmanned rocket in landing mode on target planet.");
+                                        e.setDead();
+                                        this.setDead();
+                                    }
+                                }
                     		return;
                     	}
                     }


### PR DESCRIPTION
**I have not successfully compiled this!** This is a direct translation of changes that I made via eldritch means to my own private copy of the compiled mod. It may contain syntax errors, but as the logic is exactly the same it should be free of logic errors.

I have confirmed that these changes result in the rocket arriving at its destination, as long as it can otherwise reach the target dimension. I have _not_ tested the case where the destination is entirely unloaded.

I have not thoroughly tested that these changes have no unexpected side effects, but I am confident they do not, as they only affect the case where an `EntityTieredRocket` that does _not_ completely override `onReachAtmosphere` (i.e. not a Cargo Rocket) reaches space, when it has a `destinationFrequency` set, when that destination is in another dimension, _and_ when there is not an entity riding the rocket.
