### PR TITLE
Fix checkTorchHasOxygen method getter

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/api/world/OxygenHooks.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/api/world/OxygenHooks.java
@@ -149,7 +149,7 @@ public class OxygenHooks
                 {
                     oxygenUtilClass = Class.forName("micdoodle8.mods.galacticraft.core.util.OxygenUtil");
                 }
-                torchHasOxygenMethod = oxygenUtilClass.getDeclaredMethod("isAABBInBreathableAirBlock", World.class, Block.class, int.class, int.class, int.class);
+                torchHasOxygenMethod = oxygenUtilClass.getDeclaredMethod("checkTorchHasOxygen", World.class, Block.class, int.class, int.class, int.class);
             }
             return (Boolean)torchHasOxygenMethod.invoke(null, world, block, x, y, z);
         }


### PR DESCRIPTION
Was getting an incorrect method and would never show an error as it was in a string
